### PR TITLE
Improve mobile support

### DIFF
--- a/index-dev.html
+++ b/index-dev.html
@@ -132,6 +132,22 @@
     display: none;
     z-index: 500;
   }
+
+  /* Mobile tweaks */
+  @media (max-width: 600px) {
+    #game-arena {
+      width: 95vw;
+      height: 70vh;
+      max-width: none;
+      max-height: none;
+      touch-action: manipulation;
+    }
+
+    #tower {
+      width: 60px;
+      height: 60px;
+    }
+  }
 </style>
 </head>
 <body>

--- a/index-phaser.html
+++ b/index-phaser.html
@@ -17,6 +17,8 @@
         }
         
         #game-container {
+            width: 100vw;
+            height: 100vh;
             border: 2px solid #0f3460;
             box-shadow: 0 0 20px rgba(94, 84, 142, 0.5);
         }

--- a/src/core/TowerDefenseGame.js
+++ b/src/core/TowerDefenseGame.js
@@ -53,14 +53,22 @@ export class TowerDefenseGame {
   setupEventListeners() {
     // Click to shoot
     const arena = document.getElementById('game-arena');
+    const shootHandler = (x, y) => {
+      const rect = arena.getBoundingClientRect();
+      const clickX = x - rect.left;
+      const clickY = y - rect.top;
+      this.tower.handleClick(clickX, clickY);
+    };
+
     arena.addEventListener('click', (e) => {
       if (!this.isPlaying || this.isPaused) return;
-      
-      const rect = arena.getBoundingClientRect();
-      const clickX = e.clientX - rect.left;
-      const clickY = e.clientY - rect.top;
-      
-      this.tower.handleClick(clickX, clickY);
+      shootHandler(e.clientX, e.clientY);
+    });
+
+    arena.addEventListener('touchstart', (e) => {
+      if (!this.isPlaying || this.isPaused) return;
+      const touch = e.touches[0];
+      shootHandler(touch.clientX, touch.clientY);
     });
     
     // Keyboard controls

--- a/src/phaser-game/main.js
+++ b/src/phaser-game/main.js
@@ -5,9 +5,13 @@ import { PreloadScene } from './scenes/PreloadScene.js';
 const config = {
     type: Phaser.AUTO,
     parent: 'game-container',
-    width: 1024,
-    height: 768,
     backgroundColor: '#2d2d2d',
+    scale: {
+        mode: Phaser.Scale.RESIZE,
+        autoCenter: Phaser.Scale.CENTER_BOTH,
+        width: window.innerWidth,
+        height: window.innerHeight
+    },
     scene: [PreloadScene, GameScene],
     physics: {
         default: 'arcade',
@@ -21,3 +25,7 @@ const game = new Phaser.Game(config);
 
 // Make game instance globally available for debugging
 window.game = game;
+
+window.addEventListener('resize', () => {
+    game.scale.resize(window.innerWidth, window.innerHeight);
+});


### PR DESCRIPTION
## Summary
- style responsive mobile tweaks
- allow touch controls for manual shooting
- size Phaser canvas to fit screen and scale dynamically

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_6855b0cbaca8832db010025c6bc2cab6